### PR TITLE
Enable host genome download by accession

### DIFF
--- a/resources/config/config.yaml
+++ b/resources/config/config.yaml
@@ -22,9 +22,17 @@ threads:
   host_filter: 4
   assembly: 8
 
-host_reference:
-  resources/db/bt2/GRCm39/GRCm39
-  # update this with the full path to the bowtie2 indexes of your host genome.
+
+
+host_filter:
+  db_dir: resources/test/test_dbs
+  accn: GCA_000001635.9 
+  # NCBI GenBank Accession number for the host genome assembly.
+  # This will be automatically downloaded and indexed in the location
+  # {db_dir}/bt2/{host_accn}.
+
+  # To bypass this and use an existing bt2 index, 
+  # To use 
   # Local:
   # bt2_path: '/Users/danielsprockett/db/bt2/GCF_000001635.27_GRCm39_genomic'
   # cbsumoeller@biohpc.cornell.edu:

--- a/resources/env/bowtie2.yaml
+++ b/resources/env/bowtie2.yaml
@@ -6,3 +6,4 @@ dependencies:
   - bedtools>=2.26.0
   - samtools>=1.3.1
   - pigz
+  - tbb=2020.2

--- a/resources/snakefiles/Snakefile.smk
+++ b/resources/snakefiles/Snakefile.smk
@@ -1,4 +1,5 @@
 import pandas as pd
+from os.path import join
 
 configfile: "config.yaml"
 


### PR DESCRIPTION
This PR addresses issue #13, enabling specification of host reference genome assembly by NCBI GenBank accession number and automatic downloading and indexing.

It also contains [a small fix](https://www.biostars.org/p/494922/) to the Bowtie2 environment YAML file to fix the tbblib problem that was cropping up with the bioconda recipe. 