### PR TITLE
Profiling of reads with Sourmash

### DIFF
--- a/resources/config/config.yaml
+++ b/resources/config/config.yaml
@@ -14,6 +14,10 @@ params:
     other: "--minimum-length 1 --nextseq-trim 20"
   multiqc: ''
   bowtie2: ''
+  sourmash:
+    k: 31
+    scaled: 1000
+    extra: ''
 
 threads:
   fastqc: 1

--- a/resources/env/sourmash.yaml
+++ b/resources/env/sourmash.yaml
@@ -1,0 +1,6 @@
+channels:
+  - defaults
+  - bioconda
+  - conda-forge
+dependencies:
+  - sourmash>=4.0

--- a/resources/snakefiles/Snakefile.smk
+++ b/resources/snakefiles/Snakefile.smk
@@ -29,4 +29,4 @@ include: "resources/snakefiles/sourmash.smk"
 rule all:
     input:
         "output/qc/multiqc/multiqc.html",
-        "output/sourmash/sourmash.dm"
+        "output/sourmash/plots"

--- a/resources/snakefiles/Snakefile.smk
+++ b/resources/snakefiles/Snakefile.smk
@@ -23,7 +23,7 @@ def get_read(sample, unit, read):
 
 include: "resources/snakefiles/qc.smk"
 include: "resources/snakefiles/assemble.smk"
-include: "resources/snakefiles/profile.smk"
+include: "resources/snakefiles/sourmash.smk"
 
 rule all:
     input:

--- a/resources/snakefiles/Snakefile.smk
+++ b/resources/snakefiles/Snakefile.smk
@@ -23,7 +23,9 @@ def get_read(sample, unit, read):
 
 include: "resources/snakefiles/qc.smk"
 include: "resources/snakefiles/assemble.smk"
+include: "resources/snakefiles/profile.smk"
 
 rule all:
     input:
-        "output/qc/multiqc/multiqc.html"
+        "output/qc/multiqc/multiqc.html",
+        "output/sourmash/sourmash.dm"

--- a/resources/snakefiles/profile.smk
+++ b/resources/snakefiles/profile.smk
@@ -1,0 +1,41 @@
+rule sourmash_sketch_reads:
+    input:
+        R1="output/trimmed/{sample}.combined.R1.fastq.gz",
+        R2="output/trimmed/{sample}.combined.R2.fastq.gz"
+    output:
+        "output/sourmash/sketches/{sample}.sig"
+    log:
+        "output/logs/sourmash/sourmash_sketch_reads.{sample}.log"
+    threads: 1
+    conda: "../env/sourmash.yaml"
+    params:
+        k=config['params']['sourmash']['k'],
+        scaled=config['params']['sourmash']['scaled'],
+        extra=config['params']['sourmash']['extra']
+    shell:
+        """
+        sourmash sketch dna \
+        -p k={params.k},scaled={params.scaled}  \
+        {params.extra} \
+        -o {output} \
+        --merge \
+        {input} 2> {log} 1>&2
+        """
+
+rule sourmash_dm:
+    input:
+        expand(rules.sourmash_sketch_reads.output,
+               sample=samples)
+    output:
+        "output/sourmash/sourmash.dm"
+    log:
+        "output/logs/sourmash/sourmash_dm.log"
+    threads: 1
+    conda: "../env/sourmash.yaml"
+    shell:
+        """
+        sourmash compare \
+        --output {output} \
+        {input} 2> {log} 1>&2
+        """
+

--- a/resources/snakefiles/sourmash.smk
+++ b/resources/snakefiles/sourmash.smk
@@ -27,7 +27,8 @@ rule sourmash_dm:
         expand(rules.sourmash_sketch_reads.output,
                sample=samples)
     output:
-        "output/sourmash/sourmash.dm"
+        dm="output/sourmash/sourmash.dm",
+        csv="output/sourmash/sourmash.csv"
     log:
         "output/logs/sourmash/sourmash_dm.log"
     threads: 1
@@ -35,7 +36,8 @@ rule sourmash_dm:
     shell:
         """
         sourmash compare \
-        --output {output} \
+        --output {output.dm} \
+        --csv {output.csv} \
         {input} 2> {log} 1>&2
         """
 

--- a/resources/snakefiles/sourmash.smk
+++ b/resources/snakefiles/sourmash.smk
@@ -41,3 +41,18 @@ rule sourmash_dm:
         {input} 2> {log} 1>&2
         """
 
+rule sourmash_plot:
+    input:
+        "output/sourmash/sourmash.dm"
+    output:
+        directory("output/sourmash/plots")
+    log:
+        "output/logs/sourmash/sourmash_plot.log"
+    threads: 1
+    conda: "../env/sourmash.yaml"
+    shell:
+        """
+        sourmash plot --pdf --labels \
+        --output-dir {output} \
+        {input} 2> {log} 1>&2
+        """


### PR DESCRIPTION
This PR addresses issue #15, and adds rules for minhash profiling of filtered reads using sourmash. It also uses sourmash to create a numpy-formatted distance matrix binary for all sketches in a given pipeline; the idea is that this dm can then be used directly as an input to prototype selection.

Note that, at least on my Mac, I needed to invoke snakemake with the `--conda-frontend mamba` option to get it to install the environment successfully. 