### PR TITLE
Assembly rules

### DIFF
--- a/resources/config/config.yaml
+++ b/resources/config/config.yaml
@@ -8,6 +8,10 @@ reads:
   - R1
   - R2
 
+assemblers:
+  - metaspades
+  - megahit
+
 params:
   cutadapt:
     adapter: 'GATCGGAAGAGC'
@@ -24,9 +28,12 @@ threads:
   cutadapt_pe: 4
   fastqc_post_trim: 1
   host_filter: 4
-  assembly: 8
+  spades: 8
+  megahit: 8
 
-
+mem_mb:
+  spades: 10000
+  megahit: 10000
 
 host_filter:
   db_dir: resources/test/test_dbs

--- a/resources/config/config.yaml
+++ b/resources/config/config.yaml
@@ -14,6 +14,10 @@ params:
     other: "--minimum-length 1 --nextseq-trim 20"
   multiqc: ''
   bowtie2: ''
+  sourmash:
+    k: 31
+    scaled: 1000
+    extra: ''
 
 threads:
   fastqc: 1

--- a/resources/env/assemble.yaml
+++ b/resources/env/assemble.yaml
@@ -1,0 +1,7 @@
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - spades>=3.15
+  - megahit>=1.2.9
+  - quast>=5.0.2

--- a/resources/env/sourmash.yaml
+++ b/resources/env/sourmash.yaml
@@ -1,0 +1,6 @@
+channels:
+  - defaults
+  - bioconda
+  - conda-forge
+dependencies:
+  - sourmash>=4.0

--- a/resources/snakefiles/Snakefile.smk
+++ b/resources/snakefiles/Snakefile.smk
@@ -29,4 +29,4 @@ include: "resources/snakefiles/sourmash.smk"
 rule all:
     input:
         "output/qc/multiqc/multiqc.html",
-        "output/sourmash/sourmash.dm"
+        "output/sourmash/plots"

--- a/resources/snakefiles/Snakefile.smk
+++ b/resources/snakefiles/Snakefile.smk
@@ -23,7 +23,7 @@ def get_read(sample, unit, read):
 
 include: "resources/snakefiles/qc.smk"
 include: "resources/snakefiles/assemble.smk"
-include: "resources/snakefiles/profile.smk"
+include: "resources/snakefiles/sourmash.smk"
 
 rule all:
     input:

--- a/resources/snakefiles/Snakefile.smk
+++ b/resources/snakefiles/Snakefile.smk
@@ -29,4 +29,5 @@ include: "resources/snakefiles/sourmash.smk"
 rule all:
     input:
         "output/qc/multiqc/multiqc.html",
-        "output/sourmash/plots"
+        "output/sourmash/plots",
+        "output/assemble/multiqc/multiqc.html"

--- a/resources/snakefiles/Snakefile.smk
+++ b/resources/snakefiles/Snakefile.smk
@@ -23,7 +23,9 @@ def get_read(sample, unit, read):
 
 include: "resources/snakefiles/qc.smk"
 include: "resources/snakefiles/assemble.smk"
+include: "resources/snakefiles/profile.smk"
 
 rule all:
     input:
-        "output/qc/multiqc/multiqc.html"
+        "output/qc/multiqc/multiqc.html",
+        "output/sourmash/sourmash.dm"

--- a/resources/snakefiles/assemble.smk
+++ b/resources/snakefiles/assemble.smk
@@ -8,24 +8,27 @@ rule metaspades_assembly:
         fastq1=rules.host_filter.output.nonhost_R1,
         fastq2=rules.host_filter.output.nonhost_R2
     output:
-        contigs="output/metaspades/{sample}.contigs.fasta",
+        contigs="output/assemble/metaspades/{sample}.contigs.fasta",
         temp_dir=temp(directory("output/{sample}_temp"))
     conda:
-        "resources/envs/spades.yaml"
+        "../env/spades.yaml"
     threads:
-        config['threads']['assembly']
+        config['threads']['spades']
     benchmark:
         "output/benchmarks/metaspades/{sample}_benchmark.txt"
     log:
-        "output/logs/metaspades/{sample}.metaspades.log",
+        "output/logs/metaspades/{sample}.metaspades.log"
+    resources:
+        mem_mb=config['mem_mb']['spades']
     shell:
         """
         # Make temporary output directory
         mkdir -p {output.temp_dir}
 
-        # run the metaspades assmebly
+        # run the metaspades assembly
         metaspades.py --threads {threads} \
           -o {output.temp_dir}/ \
+          --memory $(({resources.mem_mb}/1024)) \
           --pe1-1 {input.fastq1} \
           --pe1-2 {input.fastq2} \
           2> {log} 1>&2
@@ -35,4 +38,80 @@ rule metaspades_assembly:
 
         """
 
-        
+rule megahit_assembly:
+    """
+
+    Performs a metagenomic assembly on a sample using MetaSPAdes.
+
+    """
+    input:
+        fastq1=rules.host_filter.output.nonhost_R1,
+        fastq2=rules.host_filter.output.nonhost_R2
+    output:
+        contigs="output/assemble/megahit/{sample}.contigs.fasta",
+        temp_dir=temp(directory("output/{sample}_temp"))
+    conda:
+        "../env/assemble.yaml"
+    threads:
+        config['threads']['megahit']
+    benchmark:
+        "output/benchmarks/megahit/{sample}_benchmark.txt"
+    log:
+        "output/logs/megahit/{sample}.megahit.log"
+    resources:
+        mem_mb=config['mem_mb']['megahit']
+    shell:
+        """
+        # run the metaspades assembly
+        megahit -t {threads} \
+          -o {output.temp_dir}/ \
+          --memory $(({resources.mem_mb}*1024*1024)) \
+          -1 {input.fastq1} \
+          -2 {input.fastq2} \
+          2> {log} 1>&2
+
+        # move and rename the contigs file into a permanent directory
+        mv {output.temp_dir}/final.contigs.fa {output.contigs}
+
+        """
+
+rule quast:
+    """
+    Does an evaluation of assembly quality with Quast
+    """
+    input:
+        lambda wildcards: expand("output/assemble/{assembler}/{sample}.contigs.fasta",
+                                 assembler=config['assemblers'],
+                                 sample=wildcards.sample)
+    output:
+        report="output/assemble/quast/{sample}/report.txt",
+        outdir=directory("output/assemble/quast/{sample}")
+    threads:
+        1
+    log:
+        "output/logs/quast/{sample}.quast.log"
+    conda:
+        "../env/assemble.yaml"
+    benchmark:
+        "output/benchmarks/quast/{sample}_benchmark.txt"
+    shell:
+        """
+        quast.py \
+          -o {output.outdir} \
+          -t {threads} \
+          {input}
+        """
+
+
+rule multiqc_assemble:
+    input:
+        lambda wildcards: expand("output/assemble/quast/{sample}/report.txt",
+                                 sample=samples)
+    output:
+        "output/assemble/multiqc/multiqc.html"
+    params:
+        config['params']['multiqc']  # Optional: extra parameters for multiqc.
+    log:
+        "output/logs/multiqc/multiqc_assemble.log"
+    wrapper:
+        "0.72.0/bio/multiqc"

--- a/resources/snakefiles/profile.smk
+++ b/resources/snakefiles/profile.smk
@@ -1,0 +1,41 @@
+rule sourmash_sketch_reads:
+    input:
+        R1="output/trimmed/{sample}.combined.R1.fastq.gz",
+        R2="output/trimmed/{sample}.combined.R2.fastq.gz"
+    output:
+        "output/sourmash/sketches/{sample}.sig"
+    log:
+        "output/logs/sourmash/sourmash_sketch_reads.{sample}.log"
+    threads: 1
+    conda: "../env/sourmash.yaml"
+    params:
+        k=config['params']['sourmash']['k'],
+        scaled=config['params']['sourmash']['scaled'],
+        extra=config['params']['sourmash']['extra']
+    shell:
+        """
+        sourmash sketch dna \
+        -p k={params.k},scaled={params.scaled}  \
+        {params.extra} \
+        -o {output} \
+        --merge \
+        {input} 2> {log} 1>&2
+        """
+
+rule sourmash_dm:
+    input:
+        expand(rules.sourmash_sketch_reads.output,
+               sample=samples)
+    output:
+        "output/sourmash/sourmash.dm"
+    log:
+        "output/logs/sourmash/sourmash_dm.log"
+    threads: 1
+    conda: "../env/sourmash.yaml"
+    shell:
+        """
+        sourmash compare \
+        --output {output} \
+        {input} 2> {log} 1>&2
+        """
+

--- a/resources/snakefiles/sourmash.smk
+++ b/resources/snakefiles/sourmash.smk
@@ -27,7 +27,8 @@ rule sourmash_dm:
         expand(rules.sourmash_sketch_reads.output,
                sample=samples)
     output:
-        "output/sourmash/sourmash.dm"
+        dm="output/sourmash/sourmash.dm",
+        csv="output/sourmash/sourmash.csv"
     log:
         "output/logs/sourmash/sourmash_dm.log"
     threads: 1
@@ -35,7 +36,8 @@ rule sourmash_dm:
     shell:
         """
         sourmash compare \
-        --output {output} \
+        --output {output.dm} \
+        --csv {output.csv} \
         {input} 2> {log} 1>&2
         """
 

--- a/resources/snakefiles/sourmash.smk
+++ b/resources/snakefiles/sourmash.smk
@@ -41,3 +41,18 @@ rule sourmash_dm:
         {input} 2> {log} 1>&2
         """
 
+rule sourmash_plot:
+    input:
+        "output/sourmash/sourmash.dm"
+    output:
+        directory("output/sourmash/plots")
+    log:
+        "output/logs/sourmash/sourmash_plot.log"
+    threads: 1
+    conda: "../env/sourmash.yaml"
+    shell:
+        """
+        sourmash plot --pdf --labels \
+        --output-dir {output} \
+        {input} 2> {log} 1>&2
+        """


### PR DESCRIPTION
Added rules for assembly via Megahit and Metaspades. 

The choice of assembler(s) is made by a list in `config.yaml`:

```{yaml}
assemblers:
  - metaspades
  - megahit
 ```

All assemblies are executed per sample, then the per-assembler outputs summarized via Quast, then the per-sample Quast outputs summarized by MultiQC.

