### PR TITLE
Binning

### DIFF
--- a/Snakefile-bin
+++ b/Snakefile-bin
@@ -1,0 +1,1 @@
+resources/snakefiles/Snakefile-bin.smk

--- a/resources/config/binning.txt
+++ b/resources/config/binning.txt
@@ -1,0 +1,5 @@
+Sample	Contigs	To_Groups	From_Groups
+amy	output/metaspades/amy.contigs.fasta	A	A
+bob	output/metaspades/bob.contigs.fasta	A	A
+carl	output/metaspades/carl.contigs.fasta	A	
+diane	output/metaspades/diane.contigs.fasta	A	

--- a/resources/config/binning.txt
+++ b/resources/config/binning.txt
@@ -1,5 +1,5 @@
 Sample	Contigs	To_Groups	From_Groups
-amy	output/metaspades/amy.contigs.fasta	A	A
-bob	output/metaspades/bob.contigs.fasta	A	A
-carl	output/metaspades/carl.contigs.fasta	A	
-diane	output/metaspades/diane.contigs.fasta	A	
+amy	output/assemble/metaspades/amy.contigs.fasta	A	A
+bob	output/assemble/metaspades/bob.contigs.fasta	A	A
+carl	output/assemble/metaspades/carl.contigs.fasta	A	
+diane	output/assemble/metaspades/diane.contigs.fasta	A	

--- a/resources/config/config.yaml
+++ b/resources/config/config.yaml
@@ -44,6 +44,7 @@ threads:
   megahit: 8
   metaphlan: 4
   bowtie2_build: 8
+  sort_bam: 1
 
 mem_mb:
   spades: 256000

--- a/resources/config/config.yaml
+++ b/resources/config/config.yaml
@@ -22,7 +22,10 @@ params:
     adapter: 'GATCGGAAGAGC'
     other: "--minimum-length 1 --nextseq-trim 20"
   multiqc: ''
-  bowtie2: ''
+  bowtie2: 
+    bt2_command: 'bowtie2'
+    bt2b_command: 'bowtie2-build'
+    extra: ''
   sourmash:
     k: 31
     scaled: 1000
@@ -40,6 +43,7 @@ threads:
   spades: 8
   megahit: 8
   metaphlan: 4
+  bowtie2_build: 8
 
 mem_mb:
   spades: 256000

--- a/resources/config/config.yaml
+++ b/resources/config/config.yaml
@@ -4,6 +4,8 @@ samples:
 
 units: resources/config/units.txt
 
+binning: resources/config/binning.txt
+
 reads:
   - R1
   - R2

--- a/resources/snakefiles/Snakefile-bin.smk
+++ b/resources/snakefiles/Snakefile-bin.smk
@@ -81,7 +81,7 @@ include: "resources/snakefiles/mapping.smk"
 
 rule map_all:
     input:
-        expand("output/binning/mapped_reads/{from_sample}.{to_sample}.sortd.bam",
+        expand("output/binning/mapped_reads/{from_sample}.{to_sample}.sorted.bam",
                from_sample=from_samples,
                to_sample=to_samples)
 

--- a/resources/snakefiles/Snakefile-bin.smk
+++ b/resources/snakefiles/Snakefile-bin.smk
@@ -70,11 +70,14 @@ print(from_groups)
 print(from_samples)
 print(to_samples)
 
+
+
 def get_contigs(sample, binning_df):
     return(binning_df.loc[sample, 'Contigs'])
 
 
 include: "resources/snakefiles/qc.smk"
+include: "resources/snakefiles/mapping.smk"
 
 rule map_all:
     input:
@@ -82,16 +85,16 @@ rule map_all:
                from_sample=from_samples,
                to_sample=to_samples)
 
-rule map_pair:
-    input: 
-        contigs = lambda wildcards: get_contigs(wildcards.to_sample, binning_df),
-        reads = lambda wildcards: expand(rules.merge_units.output,
-                                         sample=wildcards.from_sample,
-                                         read=['R1','R2'])
-    output:
-        "output/binning/mapped_reads/{from_sample}.{to_sample}.bam"
-    run:
-        contig_fp = get_contigs(wildcards.to_sample, binning_df)
-        print("binning_df: \n%s" % binning_df)
-        print("wildcard: %s" % wildcards.to_sample)
-        print("contigs: %s" % contig_fp)
+# rule map_pair:
+#     input: 
+#         contigs = lambda wildcards: get_contigs(wildcards.to_sample, binning_df),
+#         reads = lambda wildcards: expand(rules.merge_units.output,
+#                                          sample=wildcards.from_sample,
+#                                          read=['R1','R2'])
+#     output:
+#         "output/binning/mapped_reads/{from_sample}.{to_sample}.bam"
+#     run:
+#         contig_fp = get_contigs(wildcards.to_sample, binning_df)
+#         print("binning_df: \n%s" % binning_df)
+#         print("wildcard: %s" % wildcards.to_sample)
+#         print("contigs: %s" % contig_fp)

--- a/resources/snakefiles/Snakefile-bin.smk
+++ b/resources/snakefiles/Snakefile-bin.smk
@@ -81,7 +81,7 @@ include: "resources/snakefiles/mapping.smk"
 
 rule map_all:
     input:
-        expand("output/binning/mapped_reads/{from_sample}.{to_sample}.bam",
+        expand("output/binning/mapped_reads/{from_sample}.{to_sample}.sortd.bam",
                from_sample=from_samples,
                to_sample=to_samples)
 

--- a/resources/snakefiles/Snakefile-bin.smk
+++ b/resources/snakefiles/Snakefile-bin.smk
@@ -26,6 +26,9 @@ binning_df = pd.read_csv(binning_fp,
                          sep='\t',
                          na_filter=False)
 
+def get_read(sample, unit, read):
+    return(units_table.loc[(sample, unit), read])
+
 def parse_groups(group_series):
     groups = {}
     for sample, grps in group_series.iteritems():
@@ -82,9 +85,9 @@ rule map_all:
 rule map_pair:
     input: 
         contigs = lambda wildcards: get_contigs(wildcards.to_sample, binning_df),
-        # reads = lambda wildcards: expand(rules.merge_units,
-        #                                  sample=wildcards.from_sample,
-        #                                  read=['R1','R2'])
+        reads = lambda wildcards: expand(rules.merge_units.output,
+                                         sample=wildcards.from_sample,
+                                         read=['R1','R2'])
     output:
         "output/binning/mapped_reads/{from_sample}.{to_sample}.bam"
     run:

--- a/resources/snakefiles/Snakefile-bin.smk
+++ b/resources/snakefiles/Snakefile-bin.smk
@@ -1,0 +1,94 @@
+import pandas as pd
+from os.path import join
+
+configfile: "config.yaml"
+
+samples_fp = config['samples']
+
+units_fp = config['units']
+
+reads = config['reads']
+
+sample_table = pd.read_csv(samples_fp, sep='\t', header=0)
+sample_table.set_index('Sample', inplace=True)
+
+units_table = pd.read_csv(units_fp, sep='\t', header=0)
+units_table.set_index(['Sample', 'Unit'], inplace=True)
+
+samples = sample_table.index
+units = units_table.index
+
+binning_fp = config['binning']
+
+binning_df = pd.read_csv(binning_fp, 
+                         header=0,
+                         index_col=0,
+                         sep='\t',
+                         na_filter=False)
+
+def parse_groups(group_series):
+    groups = {}
+    for sample, grps in group_series.iteritems():
+        if not grps:
+            continue
+        grp_list = grps.split(',')
+        for grp in grp_list:
+            if grp not in groups:
+                groups[grp] = [sample]
+            else:
+                groups[grp].append(sample)
+    return(groups)
+
+def make_pairings(from_grp, to_grp):
+    if from_grp.keys() != to_grp.keys():
+        raise ValueError('Not all keys in both from and to groups!')
+    
+    to_samples = []
+    from_samples = []
+    for grp in from_grp.keys():
+        f = from_grp[grp]
+        t = to_grp[grp]
+        
+        for i in f:
+            for  j in t:
+                from_samples.append(i)
+                to_samples.append(j)
+    
+    return(from_samples, to_samples)
+
+print(binning_df)
+
+to_groups = parse_groups(binning_df['To_Groups'])
+from_groups = parse_groups(binning_df['From_Groups'])
+from_samples, to_samples = make_pairings(from_groups, to_groups)
+
+print(to_groups)
+print(from_groups)
+print(from_samples)
+print(to_samples)
+
+def get_contigs(sample, binning_df):
+    return(binning_df.loc[sample, 'Contigs'])
+
+
+include: "resources/snakefiles/qc.smk"
+
+rule map_all:
+    input:
+        expand("output/binning/mapped_reads/{from_sample}.{to_sample}.bam",
+               from_sample=from_samples,
+               to_sample=to_samples)
+
+rule map_pair:
+    input: 
+        contigs = lambda wildcards: get_contigs(wildcards.to_sample, binning_df),
+        # reads = lambda wildcards: expand(rules.merge_units,
+        #                                  sample=wildcards.from_sample,
+        #                                  read=['R1','R2'])
+    output:
+        "output/binning/mapped_reads/{from_sample}.{to_sample}.bam"
+    run:
+        contig_fp = get_contigs(wildcards.to_sample, binning_df)
+        print("binning_df: \n%s" % binning_df)
+        print("wildcard: %s" % wildcards.to_sample)
+        print("contigs: %s" % contig_fp)

--- a/resources/snakefiles/mapping.smk
+++ b/resources/snakefiles/mapping.smk
@@ -1,0 +1,74 @@
+from os.path import splitext
+
+rule index_contigs:
+    input:
+        contigs = lambda wildcards: get_contigs(wildcards.to_sample,
+                                                binning_df)
+    output:
+        temp(multiext("output/binning/indexed/{to_sample}",
+                      ".1.bt2",
+                      ".2.bt2",
+                      ".3.bt2",
+                      ".4.bt2",
+                      ".rev.1.bt2",
+                      ".rev.2.bt2"))
+    log:
+        "output/logs/binning/bowtie2-build.{to_sample}.log"
+    conda:
+        "../env/bowtie2.yaml"
+    params:
+        bt2b_command = config['params']['bowtie2']['bt2b_command'],
+        extra = config['params']['bowtie2']['extra'],  # optional parameters
+        indexbase = "output/binning/indexed/{to_sample}"
+    threads:
+        config['threads']['bowtie2_build']
+    shell:
+        """
+        {params.bt2b_command} --threads {threads} {params.extra} \
+        {input.contigs} {params.indexbase} 2> {log} 1>&2
+        """
+
+rule map_reads:
+    """
+    Performs host read filtering on paired end data using Bowtie and Samtools/
+    BEDtools.
+
+    Also requires an indexed reference (path specified in config).
+
+    First, uses Bowtie output piped through Samtools to only retain read pairs
+    that are never mapped (either concordantly or just singly) to the indexed
+    reference genome. Fastqs from this are gzipped into matched forward and
+    reverse pairs.
+
+    Unpaired forward and reverse reads are simply run through Bowtie and
+    non-mapping gzipped reads output.
+
+    All piped output first written to localscratch to avoid tying up filesystem.
+    """
+    input:
+        reads = lambda wildcards: expand(rules.merge_units.output,
+                                         sample=wildcards.from_sample,
+                                         read=['R1','R2']),
+        db=rules.index_contigs.output
+    output:
+        aln="output/binning/mapped_reads/{from_sample}.{to_sample}.bam"
+    params:
+        ref="output/binning/indexed/{to_sample}",
+        bt2_command = config['params']['bowtie2']['bt2_command'],
+        extra = config['params']['bowtie2']['extra'],  # optional parameters
+    conda:
+        "../env/bowtie2.yaml"
+    threads:
+        config['threads']['host_filter']
+    benchmark:
+        "output/benchmarks/bowtie2/{from_sample}.{to_sample}.benchmark.txt"
+    log:
+        "output/logs/binning/{from_sample}.{to_sample}.bowtie.log"
+    shell:
+        """
+        # Map reads against reference genome
+        {params.bt2_command} -p {threads} -x {params.ref} \
+          -1 {input.reads[0]} -2 {input.reads[1]} \
+          2> {log} | samtools view -bS - > {output.aln}
+
+        """

--- a/resources/snakefiles/mapping.smk
+++ b/resources/snakefiles/mapping.smk
@@ -51,7 +51,7 @@ rule map_reads:
                                          read=['R1','R2']),
         db=rules.index_contigs.output
     output:
-        aln="output/binning/mapped_reads/{from_sample}.{to_sample}.bam"
+        aln=temp("output/binning/mapped_reads/{from_sample}.{to_sample}.bam")
     params:
         ref="output/binning/indexed/{to_sample}",
         bt2_command = config['params']['bowtie2']['bt2_command'],
@@ -72,3 +72,27 @@ rule map_reads:
           2> {log} | samtools view -bS - > {output.aln}
 
         """
+
+rule sort_bam:
+    """
+    Sorts a bam file.
+    """
+    input:
+        aln="output/binning/mapped_reads/{from_sample}.{to_sample}.bam"
+    output:
+        bam="output/binning/mapped_reads/{from_sample}.{to_sample}.sorted.bam"
+    conda:
+        "../env/bowtie2.yaml"
+    threads:
+        config['threads']['sort_bam']
+    benchmark:
+        "output/benchmarks/samtools/{from_sample}.{to_sample}.sorted.txt"
+    log:
+        "output/logs/binning/{from_sample}.{to_sample}.sort.log"
+    shell:
+        """
+        samtools sort -o {output.bam} {input.aln} 2> {log}
+        """
+
+
+

--- a/resources/snakefiles/mapping.smk
+++ b/resources/snakefiles/mapping.smk
@@ -91,7 +91,7 @@ rule sort_bam:
         "output/logs/binning/{from_sample}.{to_sample}.sort.log"
     shell:
         """
-        samtools sort -o {output.bam} {input.aln} 2> {log}
+        samtools sort -o {output.bam} {input.aln} 2> {log}  
         """
 
 

--- a/resources/snakefiles/mapping.smk
+++ b/resources/snakefiles/mapping.smk
@@ -91,7 +91,8 @@ rule sort_bam:
         "output/logs/binning/{from_sample}.{to_sample}.sort.log"
     shell:
         """
-        samtools sort -o {output.bam} {input.aln} 2> {log}  
+        samtools sort -o {output.bam} {input.aln} 2> {log}
+
         """
 
 


### PR DESCRIPTION
This PR adds the ability to map arbitrary sets of samples against one another.

As input, it requires a `binning.txt` file specified in `config.yaml` that organizes samples into groups:

```
Sample	Contigs	To_Groups	From_Groups
amy	output/assemble/metaspades/amy.contigs.fasta	A	A
bob	output/assemble/metaspades/bob.contigs.fasta	A	A
carl	output/assemble/metaspades/carl.contigs.fasta	A	
diane	output/assemble/metaspades/diane.contigs.fasta	A	
```

Samples in `To_Group` A will all have reads from `From_Group` A mapped to their assembly; samples with no `From_Group` will not have their reads mapped to any assemblies. If a sample has a `From_Group` but no `To_Group`, its reads will be used for mapping to assemblies, but its assembly will not be mapped to. 

Samples can belong to multiple `From_` and `To_Groups` by delimiting the group identifiers with a comma; thus a sample with `From_Group A,B; To_Group A` would have its reads mapped against every sample in `To_Groups` A and B, but would only have reads mapped against its assembly from samples in `To_Group` A. 

Currently, the sorted bam file `from_sample.to_sample.sorted.bam` is the final step of the workflow, while the unsorted bam file `from_sample.to_sample.bam` is declared as a temp file and thus deleted after generation of the sorted file.,