### PR TITLE
43 rename envs

### DIFF
--- a/resources/config/binning.txt
+++ b/resources/config/binning.txt
@@ -1,5 +1,5 @@
 Sample	Contigs	Read_Groups	Contig_Groups
-amy	output/assemble/metaspades/amy.contigs.fasta	A	A
-bob	output/assemble/metaspades/bob.contigs.fasta	A	A
-carl	output/assemble/metaspades/carl.contigs.fasta		A
-diane	output/assemble/metaspades/diane.contigs.fasta		A
+amy	output/assemble/megahit/amy.contigs.fasta	A	A
+bob	output/assemble/megahit/bob.contigs.fasta	A	A
+carl	output/assemble/megahit/carl.contigs.fasta		A
+diane	output/assemble/megahit/diane.contigs.fasta		A

--- a/resources/config/config.yaml
+++ b/resources/config/config.yaml
@@ -11,8 +11,8 @@ reads:
   - R2
 
 assemblers:
-  - metaspades
-#  - megahit
+#  - metaspades
+  - megahit
 
 biobakery:
   - metaphlan

--- a/resources/env/binning_concoct_linux.yaml
+++ b/resources/env/binning_concoct_linux.yaml
@@ -1,0 +1,7 @@
+channels:
+  - defaults
+  - bioconda
+  - conda-forge
+dependencies:
+  - python=3
+  - concoct=1

--- a/resources/env/binning_concoct_osx.yaml
+++ b/resources/env/binning_concoct_osx.yaml
@@ -1,0 +1,8 @@
+channels:
+  - defaults
+  - bioconda
+  - conda-forge
+dependencies:
+  - python=2.7
+  - concoct=0.4.2
+  - samtools=1.13

--- a/resources/env/mapping.yaml
+++ b/resources/env/mapping.yaml
@@ -1,0 +1,11 @@
+channels:
+  - bioconda
+dependencies:
+  - python>=3.5
+  - bowtie2>=2.3.0
+  - bedtools>=2.26.0
+  - samtools>=1.3.1
+  - pigz
+  - entrez-direct
+  - tbb=2020.2
+  - minimap2

--- a/resources/env/profile.yaml
+++ b/resources/env/profile.yaml
@@ -8,5 +8,6 @@ dependencies:
   - bracken=>2.6.0
   - krona
   - python>=3.7
+  - numpy>=1.20
   - humann>=3.0
   - bowtie2>=2.3.0

--- a/resources/env/prototype_selection.yaml
+++ b/resources/env/prototype_selection.yaml
@@ -1,0 +1,11 @@
+channels:
+  - defaults
+  - bioconda
+  - conda-forge
+dependencies:
+  - sourmash>=4.0
+  - python>=3.6
+  - scikit-bio=0.5
+  - scikit-learn
+  - biom-format
+  - seaborn

--- a/resources/env/qc.yaml
+++ b/resources/env/qc.yaml
@@ -1,0 +1,11 @@
+channels:
+  - bioconda
+dependencies:
+  - python>=3.5
+  - bowtie2>=2.3.0
+  - bedtools>=2.26.0
+  - samtools>=1.3.1
+  - pigz
+  - entrez-direct
+  - tbb=2020.2
+  - minimap2

--- a/resources/snakefiles/Snakefile-bin.smk
+++ b/resources/snakefiles/Snakefile-bin.smk
@@ -74,13 +74,6 @@ print('Contig Pairings: %s' % contig_pairings)
 def get_contigs(sample, binning_df):
     return(binning_df.loc[sample, 'Contigs'])
 
-# def get_bam_list(sample, mapper, contig_pairings):
-#     fp = expand("output/binning/{mapper}/mapped_reads/{contig_pairings}_Mapped_To_{sample}.sorted.bam",
-#     mapper = mapper,
-#     sample = sample,
-#     contig_pairings = contig_pairings[sample])
-#     return(fp)
-
 include: "resources/snakefiles/qc.smk"
 include: "resources/snakefiles/assemble.smk"
 include: "resources/snakefiles/mapping.smk"
@@ -88,10 +81,10 @@ include: "resources/snakefiles/binning.smk"
 
 rule map_all:
     input:
-        expand("output/binning/{mapper}/sorted_bams/{pairing[0]}_Mapped_To_{pairing[1]}.sorted.bam",
+        expand("output/mapping/{mapper}/sorted_bams/{pairing[0]}_Mapped_To_{pairing[1]}.sorted.bam",
                 mapper=config['mappers'],
                 pairing=pairings),
-        # expand("output/binning/metabat2/{mapper}/{contig_sample}_coverage_table.txt",
+        # expand("output/binning/metabat2/{mapper}/coverage_tables/{contig_sample}_coverage_table.txt",
         #         mapper=config['mappers'],
         #         contig_sample=contig_groups['A']),
         expand("output/binning/metabat2/{mapper}/run_metabat2/{contig_sample}/",
@@ -102,16 +95,13 @@ rule map_all:
         #         pairing=pairings),
         # expand("output/binning/maxbin2/{mapper}/abundance_lists/{contig_sample}_abund_list.txt",
         #         mapper=config['mappers'],
-        #         contig_sample=contig_groups['A'])
+        #         contig_sample=contig_groups['A']),
         expand("output/binning/maxbin2/{mapper}/run_maxbin2/{contig_sample}_bins",
                 mapper=config['mappers'],
                 contig_sample=contig_groups['A']),
-        # expand("output/binning/maxbin2/{mapper}/{contig_sample}_abund_list.txt",
-        #         mapper=config['mappers'],
-        #         contig_sample=contig_groups['A']),
-        # expand("output/binning/maxbin2/{mapper}/run_maxbin2/{contig_sample}_bins",
-        #         mapper=config['mappers'],
-        #         contig_sample=contig_groups['A']),
-        # expand("output/binning/concoct/{mapper}/{contig_sample}_coverage_table.txt",
-        #         mapper=config['mappers'],
-        #         contig_sample=contig_groups['A'])
+        expand("output/binning/concoct/{mapper}/contigs_10K/{contig_sample}.bed",
+                mapper=config['mappers'],
+                contig_sample=contig_groups['A']),
+        expand("output/binning/concoct/{mapper}/coverage_tables/{contig_sample}_coverage_table.txt",
+                mapper=config['mappers'],
+                contig_sample=contig_groups['A'])

--- a/resources/snakefiles/Snakefile.smk
+++ b/resources/snakefiles/Snakefile.smk
@@ -24,13 +24,13 @@ def get_read(sample, unit, read):
 
 include: "resources/snakefiles/qc.smk"
 include: "resources/snakefiles/assemble.smk"
-include: "resources/snakefiles/sourmash.smk"
+include: "resources/snakefiles/prototype_selection.smk"
 include: "resources/snakefiles/profile.smk"
 
 rule all:
     input:
         "output/qc/multiqc/multiqc.html",
-        "output/sourmash/plots",
-        "output/sourmash/selected_prototypes.yaml",
+        "output/prototype_selection/plots",
+        "output/prototype_selection/selected_prototypes.yaml",
         "output/assemble/multiqc/multiqc.html",
-        "output/metaphlan/merged_abundance_table.txt"
+        "output/profile/merged_abundance_table.txt"

--- a/resources/snakefiles/Snakefile.smk
+++ b/resources/snakefiles/Snakefile.smk
@@ -30,7 +30,7 @@ include: "resources/snakefiles/profile.smk"
 rule all:
     input:
         "output/qc/multiqc/multiqc.html",
-        "output/prototype_selection/plots",
-        "output/prototype_selection/selected_prototypes.yaml",
         "output/assemble/multiqc/multiqc.html",
-        "output/profile/merged_abundance_table.txt"
+        "output/prototype_selection/sourmash_plot",
+        "output/prototype_selection/prototype_selection/selected_prototypes.yaml",
+        "output/profile/metaphlan/merged_abundance_table.txt"

--- a/resources/snakefiles/assemble.smk
+++ b/resources/snakefiles/assemble.smk
@@ -151,14 +151,15 @@ rule metaquast:
 
 rule multiqc_metaquast:
     input:
-        lambda wildcards: expand("output/assemble/{assembler}/metaquast/{sample}/report.html",
-                                 assembler=config['assemblers'],
+        lambda wildcards: expand("output/assemble/metaquast/{sample}/report.html",
                                  sample=samples)
     output:
         "output/assemble/multiqc_metaquast/multiqc.html"
     params:
         config['params']['multiqc']  # Optional: extra parameters for multiqc.
     log:
-        "output/logs/assemble/multiqc/multiqc_metaquast.log"
+        "output/logs/assemble/multiqc_metaquast/multiqc_metaquast.log"
+    benchmark:
+        "output/benchmarks/assemble/multiqc_metaquast/multiqc_metaquast.log"
     wrapper:
         "0.72.0/bio/multiqc"

--- a/resources/snakefiles/mapping.smk
+++ b/resources/snakefiles/mapping.smk
@@ -15,7 +15,7 @@ rule index_contigs_bt2:
     log:
         "output/logs/binning/bowtie2-build.{contig_sample}.log"
     conda:
-        "../env/bowtie2.yaml"
+        "../env/mapping.yaml"
     params:
         bt2b_command = config['params']['bowtie2']['bt2b_command'],
         extra = config['params']['bowtie2']['extra'],  # optional parameters
@@ -44,7 +44,7 @@ rule map_reads_bt2:
         bt2_command = config['params']['bowtie2']['bt2_command'],
         extra = config['params']['bowtie2']['extra'],  # optional parameters
     conda:
-        "../env/bowtie2.yaml"
+        "../env/mapping.yaml"
     threads:
         config['threads']['map_reads']
     benchmark:
@@ -70,7 +70,7 @@ rule index_contigs_minimap2:
     log:
         "output/logs/binning/minimap2.index.{contig_sample}.log"
     conda:
-        "../env/bowtie2.yaml"
+        "../env/mapping.yaml"
     threads:
         config['threads']['minimap2_index']
     shell:
@@ -94,7 +94,7 @@ rule map_reads_minimap2:
         x=config['params']['minimap2']['x'],
         k=config['params']['minimap2']['k']
     conda:
-        "../env/bowtie2.yaml"
+        "../env/mapping.yaml"
     threads:
         config['threads']['minimap2_map_reads']
     benchmark:
@@ -119,7 +119,7 @@ rule sort_index_bam:
         bam="output/binning/{mapper}/sorted_bams/{read_sample}_Mapped_To_{contig_sample}.sorted.bam",
         bai="output/binning/{mapper}/sorted_bams/{read_sample}_Mapped_To_{contig_sample}.sorted.bam.bai"
     conda:
-        "../env/bowtie2.yaml"
+        "../env/mapping.yaml"
     threads:
         config['threads']['sort_bam']
     benchmark:

--- a/resources/snakefiles/profile.smk
+++ b/resources/snakefiles/profile.smk
@@ -16,9 +16,9 @@ rule taxonomy_kraken:
     threads:
         config['threads']['kraken2']
     log:
-        "output/logs/kraken2/taxonomy_kraken.sample_{sample}.log"
+        "output/logs/profile/kraken2/taxonomy_kraken/{sample}.log"
     benchmark:
-        "output/benchmarks/kraken2/taxonomy_kraken.sample_{sample}.txt"
+        "output/benchmarks/profile/kraken2/taxonomy_kraken/{sample}_benchmark.txt"
     shell:
         """
           # get stem file path
@@ -63,7 +63,9 @@ rule krona:
     threads:
         1
     log:
-        "output/logs/krona/krona.sample_{sample}.log"
+        "output/logs/profile/krona/{sample}.log"
+    benchmark:
+        "output/benchmarks/profile/krona/{sample}_benchmark.txt"
     shell:
         """
         perl resources/scripts/kraken2-translate.pl {input} > {input}.temp
@@ -84,9 +86,9 @@ rule download_metaphlan_db:
     conda:
         "../env/profile.yaml"
     log:
-        "output/logs/metaphlan/download_metaphlan_db.log"
+        "output/logs/profile/download_metaphlan_db/download_metaphlan_db.log"
     benchmark:
-        "output/benchmarks/metaphlan/download_metaphlan_db_benchmark.txt"
+        "output/benchmarks/profile/download_metaphlan_db/download_metaphlan_db_benchmark.txt"
     shell:
         """
             # Download the database
@@ -94,7 +96,6 @@ rule download_metaphlan_db:
             2> {log} 1>&2
 
         """
-
 
 rule metaphlan:
     """
@@ -107,19 +108,19 @@ rule metaphlan:
         fastq2=rules.host_filter.output.nonhost_R2,
         db_path=rules.download_metaphlan_db.output
     output:
-        bt2="output/metaphlan/bowtie2s/{sample}.bowtie2.bz2",
-        sam="output/metaphlan/sams/{sample}.sam.bz2",
-        profile="output/metaphlan/profiles/{sample}_profile.txt",
+        bt2="output/profile/metaphlan/bowtie2s/{sample}.bowtie2.bz2",
+        sam="output/profile/metaphlan/sams/{sample}.sam.bz2",
+        profile="output/profile/metaphlan/profiles/{sample}_profile.txt"
     conda:
         "../env/profile.yaml"
     threads:
         config['threads']['metaphlan']
     params:
-        other=config['params']['metaphlan']['other'],
+        other=config['params']['metaphlan']['other']
     benchmark:
-        "output/benchmarks/metaphlan/{sample}_benchmark.txt"
+        "output/benchmarks/profile/metaphlan/{sample}_benchmark.txt"
     log:
-        "output/logs/metaphlan/{sample}.metaphlan.log"
+        "output/logs/profile/metaphlan/{sample}.log"
     shell:
         """
         metaphlan {input.fastq1},{input.fastq2} \
@@ -139,14 +140,16 @@ rule merge_metaphlan_tables:
 
     """
     input:
-        expand(rules.run_metaphlan.output.profile,
+        expand(rules.metaphlan.output.profile,
                sample=samples)
     output:
-        merged_abundance_table="output/metaphlan/merged_abundance_table.txt"
+        merged_abundance_table="output/profile/metaphlan/merged_abundance_table.txt"
     conda:
         "../env/profile.yaml"
     log:
-        "output/logs/metaphlan/metaphlan.merged_abundance_table.log"
+        "output/logs/profile/metaphlan/merge_metaphlan_tables/merged_abundance_table.log"
+    benchmark:
+        "output/benchmarks/profile/metaphlan/merge_metaphlan_tables/merged_abundance_table_benchmark.txt"
     shell:
         """
         merge_metaphlan_tables.py {input} \

--- a/resources/snakefiles/prototype_selection.smk
+++ b/resources/snakefiles/prototype_selection.smk
@@ -168,12 +168,14 @@ def prototype_selection_destructive_maxdist(dm, num_prototypes, seedset=None):
 
 rule sourmash_sketch_reads:
     input:
-        R1 = "output/filtered/nonhost/{sample}.1.fastq.gz",
-        R2 = "output/filtered/nonhost/{sample}.2.fastq.gz"
+        fastq1=rules.host_filter.output.nonhost_R1,
+        fastq2=rules.host_filter.output.nonhost_R2
     output:
-        "output/sourmash/sketches/{sample}.sig"
+        "output/prototype_selection/sourmash_sketch_reads/{sample}.sig"
     log:
-        "output/logs/sourmash/sourmash_sketch_reads.{sample}.log"
+        "output/logs/prototype_selection/sourmash_sketch_reads/{sample}.log"
+    benchmark:
+        "output/benchmarks/prototype_selection/sourmash_sketch_reads/{sample}_benchmark.txt"
     threads: 1
     conda: "../env/prototype_selection.yaml"
     params:
@@ -195,11 +197,11 @@ rule sourmash_dm:
         expand(rules.sourmash_sketch_reads.output,
                sample=samples)
     output:
-        dm = "output/sourmash/sourmash.dm",
-        csv = "output/sourmash/sourmash.csv",
-        labels = "output/sourmash/sourmash.dm.labels.txt"
+        dm = "output/prototype_selection/sourmash_dm/sourmash.dm",
+        csv = "output/prototype_selection/sourmash_dm/sourmash.csv",
+        labels = "output/prototype_selection/sourmash_dm/sourmash.dm.labels.txt"
     log:
-        "output/logs/sourmash/sourmash_dm.log"
+        "output/logs/prototype_selection/sourmash_dm/sourmash_dm.log"
     threads: 1
     conda: "../env/prototype_selection.yaml"
     shell:
@@ -212,11 +214,11 @@ rule sourmash_dm:
 
 rule sourmash_plot:
     input:
-        "output/sourmash/sourmash.dm"
+        rules.sourmash_dm.output.dm
     output:
-        directory("output/sourmash/plots")
+        directory("output/prototype_selection/sourmash_plot/")
     log:
-        "output/logs/sourmash/sourmash_plot.log"
+        "output/logs/prototype_selection/sourmash_plot/sourmash_plot.log"
     threads: 1
     conda: "../env/prototype_selection.yaml"
     shell:
@@ -231,12 +233,12 @@ rule prototype_selection:
         dm = rules.sourmash_dm.output.csv,
         labels = rules.sourmash_dm.output.labels
     output:
-        file = "output/sourmash/selected_prototypes.yaml"
+        file = "output/prototype_selection/prototype_selection/selected_prototypes.yaml"
     params:
         min_seqs = config['params']['prototypes']['min_seqs'],
         max_seqs = config['params']['prototypes']['max_seqs']
     log:
-        "output/logs/sourmash/prototype_selection.log"
+        "output/logs/prototype_selection/prototype_selection/prototype_selection.log"
     threads: 1
     run:
         df = pd.read_csv(input[0], header=0, encoding= 'unicode_escape')

--- a/resources/snakefiles/prototype_selection.smk
+++ b/resources/snakefiles/prototype_selection.smk
@@ -1,0 +1,283 @@
+import numpy as np
+import pandas as pd
+import gzip
+from os import path
+from skbio import DistanceMatrix
+from yaml import dump
+
+def _validate_parameters(dm, num_prototypes, seedset=None):
+    '''Validate the paramters for each algorithm.
+    Parameters
+    ----------
+    dm: skbio.stats.distance.DistanceMatrix
+        Pairwise distances for all elements in the full set S.
+    num_prototypes: int
+        Number of prototypes to select for distance matrix.
+        Must be >= 2, since a single prototype is useless.
+        Must be smaller than the number of elements in the distance matrix,
+        otherwise no reduction is necessary.
+    seedset: iterable of str
+        A set of element IDs that are pre-selected as prototypes. Remaining
+        prototypes are then recruited with the prototype selection algorithm.
+        Warning: It will most likely violate the global objective function.
+    Raises
+    ------
+    ValueError
+        The number of prototypes to be found should be at least 2 and at most
+        one element smaller than elements in the distance matrix. Otherwise, a
+        ValueError is raised.
+        The IDs in the seed set must be unique, and must be present in the
+        distance matrix. Otherwise, a ValueError is raised.
+        The size of the seed set must be smaller than the number of prototypes
+        to be found. Otherwise, a ValueError is raised.
+    '''
+    if num_prototypes < 2:
+        raise ValueError("'num_prototypes' must be >= 2, since a single "
+                         "prototype is useless.")
+    if num_prototypes >= dm.shape[0]:
+        raise ValueError("'num_prototypes' must be smaller than the number of "
+                         "elements in the distance matrix, otherwise no "
+                         "reduction is necessary.")
+    if seedset is not None:
+        seeds = set(seedset)
+        if len(seeds) < len(seedset):
+            raise ValueError("There are duplicated IDs in 'seedset'.")
+        if not seeds < set(dm.ids):  # test if set A is a subset of set B
+            raise ValueError("'seedset' is not a subset of the element IDs in "
+                             "the distance matrix.")
+        if len(seeds) >= num_prototypes:
+            raise ValueError("Size of 'seedset' must be smaller than the "
+                             "number of prototypes to select.")
+
+def prototype_selection_destructive_maxdist(dm, num_prototypes, seedset=None):
+    '''Heuristically select k prototypes for given distance matrix.
+
+       Prototype selection is NP-hard. This is an implementation of a greedy
+       correctness heuristic: Start with the complete set and iteratively
+       remove elements until the number of required prototypes is left.
+       The decision which element shall be removed is based on the minimal
+       distance sum this element has to all other.
+
+    Parameters
+    ----------
+    dm: skbio.stats.distance.DistanceMatrix
+        Pairwise distances for all elements in the full set S.
+    num_prototypes: int
+        Number of prototypes to select for distance matrix.
+        Must be >= 2, since a single prototype is useless.
+        Must be smaller than the number of elements in the distance matrix,
+        otherwise no reduction is necessary.
+    seedset: iterable of str
+        A set of element IDs that are pre-selected as prototypes. Remaining
+        prototypes are then recruited with the prototype selection algorithm.
+        Warning: It will most likely violate the global objective function.
+
+    Returns
+    -------
+    list of str
+        A sequence holding selected prototypes, i.e. a sub-set of the
+        IDs of the elements in the distance matrix.
+
+    Raises
+    ------
+    ValueError
+        The number of prototypes to be found should be at least 2 and at most
+        one element smaller than elements in the distance matrix. Otherwise, a
+        ValueError is raised.
+
+    Notes
+    -----
+    Timing: %timeit -n 100 prototype_selection_destructive_maxdist(dm, 100)
+            100 loops, best of 3: 2.1 s per loop
+            where the dm holds 27,398 elements
+    function signature with type annotation for future use with python >= 3.5:
+    def prototype_selection_constructive_maxdist(dm: DistanceMatrix,
+    num_prototypes: int, seedset: List[str]) -> List[str]:
+
+    ...
+    LICENSE
+    From https://github.com/biocore/wol/tree/master/code/prototypeSelection
+
+    Copyright (c) 2017--, WoL development team. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    * Neither the name of the copyright holder nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+    '''
+    _validate_parameters(dm, num_prototypes, seedset)
+
+    # clever bookkeeping allows for significant speed-ups!
+
+    # track the number of available elements
+    numRemain = len(dm.ids)
+
+    # distances from each element to all others
+    currDists = dm.data.sum(axis=1)
+
+    # a dirty hack to ensure that all elements of the seedset will be selected
+    # last and thus make it into the resulting set
+    maxVal = currDists.max()
+    if seedset is not None:
+        for e in seedset:
+            currDists[dm.index(e)] = maxVal*2
+
+    # the element to remove first is the one that has smallest distance to all
+    # other. "Removing" works by tagging its distance-sum as infinity. Plus, we
+    # decrease the number of available elements by one.
+    minElmIdx = currDists.argmin()
+    currDists[minElmIdx], numRemain = np.infty, numRemain-1
+
+    # continue until only num_prototype elements are left
+    while (numRemain > num_prototypes):
+        # substract the distance to the removed element for all remaining
+        # elements
+        currDists -= dm.data[minElmIdx]
+        # find the next element to be removed, again as the one that is
+        # closest to all others
+        minElmIdx = currDists.argmin()
+        currDists[minElmIdx], numRemain = np.infty, numRemain-1
+
+    # return a list of IDs of the surviving elements, which are the found
+    # prototypes.
+    return [dm.ids[idx]
+            for idx, dist in enumerate(currDists)
+            if dist != np.infty]
+
+
+rule sourmash_sketch_reads:
+    input:
+        R1 = "output/filtered/nonhost/{sample}.1.fastq.gz",
+        R2 = "output/filtered/nonhost/{sample}.2.fastq.gz"
+    output:
+        "output/sourmash/sketches/{sample}.sig"
+    log:
+        "output/logs/sourmash/sourmash_sketch_reads.{sample}.log"
+    threads: 1
+    conda: "../env/prototype_selection.yaml"
+    params:
+        k = config['params']['sourmash']['k'],
+        scaled = config['params']['sourmash']['scaled'],
+        extra = config['params']['sourmash']['extra']
+    shell:
+        """
+        sourmash sketch dna \
+        -p k={params.k},scaled={params.scaled}  \
+        {params.extra} \
+        -o {output} \
+        --merge \
+        {input} 2> {log} 1>&2
+        """
+
+rule sourmash_dm:
+    input:
+        expand(rules.sourmash_sketch_reads.output,
+               sample=samples)
+    output:
+        dm = "output/sourmash/sourmash.dm",
+        csv = "output/sourmash/sourmash.csv",
+        labels = "output/sourmash/sourmash.dm.labels.txt"
+    log:
+        "output/logs/sourmash/sourmash_dm.log"
+    threads: 1
+    conda: "../env/prototype_selection.yaml"
+    shell:
+        """
+        sourmash compare \
+        --output {output.dm} \
+        --csv {output.csv} \
+        {input} 2> {log} 1>&2
+        """
+
+rule sourmash_plot:
+    input:
+        "output/sourmash/sourmash.dm"
+    output:
+        directory("output/sourmash/plots")
+    log:
+        "output/logs/sourmash/sourmash_plot.log"
+    threads: 1
+    conda: "../env/prototype_selection.yaml"
+    shell:
+        """
+        sourmash plot --pdf --labels \
+        --output-dir {output} \
+        {input} 2> {log} 1>&2
+        """
+
+rule prototype_selection:
+    input:
+        dm = rules.sourmash_dm.output.csv,
+        labels = rules.sourmash_dm.output.labels
+    output:
+        file = "output/sourmash/selected_prototypes.yaml"
+    params:
+        min_seqs = config['params']['prototypes']['min_seqs'],
+        max_seqs = config['params']['prototypes']['max_seqs']
+    log:
+        "output/logs/sourmash/prototype_selection.log"
+    threads: 1
+    run:
+        df = pd.read_csv(input[0], header=0, encoding= 'unicode_escape')
+        df.index = df.columns
+
+        # test file sizes
+
+        pf_seqs = []
+        for fp in df.columns:
+            print(fp)
+            with gzip.open(fp, 'rb') as f:
+                for i, l in enumerate(f):
+                    pass
+            seqs = (i + 1) / 4
+            print(seqs)
+            if params['min_seqs'] <= seqs <= params['max_seqs']:
+                pf_seqs.append(fp)
+
+        df_filt = df.loc[pf_seqs, pf_seqs]
+
+        labels = [os.path.basename(x) for x in pf_seqs]
+
+        dm = DistanceMatrix(1 - df_filt.values)
+
+        print("The imported distance matrix has "
+              "{} elements.".format(len(labels)))
+        print("Selecting 2 to {} prototypes.\n".format(len(labels) - 1))
+
+        proto_dict = {}
+
+        for k in range(2, len(labels)):
+            # run prototypeSelection function
+            prototypes = prototype_selection_destructive_maxdist(dm, k)
+            proto_dict[k] = [labels[int(x)] for x in prototypes]
+
+        with open(output[0], 'w') as outfile:
+            dump(proto_dict, outfile, default_flow_style=False)
+
+        with open(log[0], "w") as logfile:
+            logfile.write("Running the run_prototypeSelection.py script.\n"
+                          "The imported distance matrix has {0} elements.\n"
+                          "Selecting 2 to "
+                          "{1} prototypes.\n".format(df.shape[1],
+                                                     len(labels) - 1))

--- a/resources/snakefiles/qc.smk
+++ b/resources/snakefiles/qc.smk
@@ -69,7 +69,7 @@ rule download_NCBI_assembly:
     threads: 1
     log: "output/logs/setup/download_NCBI_assembly.{accn}.log"
     conda:
-        "../env/bowtie2.yaml"
+        "../env/qc.yaml"
     shell: "esearch -db assembly -query {params.accn} | \
             elink -target nucleotide -name assembly_nuccore_insdc | \
             efetch -format fasta > {output}"
@@ -90,7 +90,7 @@ rule host_bowtie2_build:
     log:
         "output/logs/host_bowtie2_build/bowtie2-build.log"
     conda:
-        "../env/bowtie2.yaml"
+        "../env/qc.yaml"
     params:
         extra="",  # optional parameters,
         indexbase=join(config['host_filter']['db_dir'],
@@ -132,7 +132,7 @@ rule host_filter:
         ref=join(config['host_filter']['db_dir'],
                  config['host_filter']['accn'])
     conda:
-        "../env/bowtie2.yaml"
+        "../env/qc.yaml"
     threads:
         config['threads']['host_filter']
     benchmark:

--- a/resources/snakefiles/qc.smk
+++ b/resources/snakefiles/qc.smk
@@ -4,9 +4,13 @@ rule fastqc_pre_trim:
                                    wildcards.unit,
                                    wildcards.read)
     output:
-        html="output/qc/fastqc/pre_trim/{sample}.{unit}.{read}.html",
-        zip="output/qc/fastqc/pre_trim/{sample}.{unit}.{read}_fastqc.zip" #  the suffix _fastqc.zip is necessary for multiqc to find the file. If not using multiqc, you are free to choose an arbitrary filename
+        html="output/qc/fastqc_pre_trim/{sample}.{unit}.{read}.html",
+        zip="output/qc/fastqc_pre_trim/{sample}.{unit}.{read}_fastqc.zip" #  the suffix _fastqc.zip is necessary for multiqc to find the file. If not using multiqc, you are free to choose an arbitrary filename
     params: ""
+    benchmark:
+        "output/benchmarks/qc/fastqc_pre_trim/{sample}.{unit}.{read}_benchmark.txt"
+    log:
+        "output/logs/qc/fastqc_pre_trim/{sample}.{unit}.{read}.log"
     threads:
         config['threads']['fastqc']
     wrapper:
@@ -21,12 +25,16 @@ rule cutadapt_pe:
                                    wildcards.unit,
                                    'R2')
     output:
-        fastq1=temp("output/trimmed/{sample}.{unit}.R1.fastq.gz"),
-        fastq2=temp("output/trimmed/{sample}.{unit}.R2.fastq.gz"),
-        qc="output/logs/cutadapt/{sample}.{unit}.qc.txt"
+        fastq1=temp("output/qc/cutadapt_pe/{sample}.{unit}.R1.fastq.gz"),
+        fastq2=temp("output/qc/cutadapt_pe/{sample}.{unit}.R2.fastq.gz"),
+        qc="output/logs/qc/cutadapt_pe/{sample}.{unit}.txt"
     params:
         "-a {} {}".format(config["params"]["cutadapt"]['adapter'],
                           config["params"]["cutadapt"]['other'])
+    benchmark:
+        "output/benchmarks/qc/cutadapt_pe/{sample}.{unit}_benchmark.txt"
+    log:
+        "output/logs/qc/cutadapt_pe/{sample}.{unit}.log"
     threads:
         config['threads']['cutadapt_pe']
     wrapper:
@@ -34,25 +42,32 @@ rule cutadapt_pe:
 
 rule fastqc_post_trim:
     input:
-        "output/trimmed/{sample}.{unit}.{read}.fastq.gz"
+        "output/qc/cutadapt_pe/{sample}.{unit}.{read}.fastq.gz"
     output:
-        html="output/qc/fastqc/post_trim/{sample}.{unit}.{read}.trimmed.html",
-        zip="output/qc/fastqc/post_trim/{sample}.{unit}.{read}.trimmed_fastqc.zip" # the suffix _fastqc.zip is necessary for multiqc to find the file. If not using multiqc, you are free to choose an arbitrary filename
+        html="output/qc/fastqc_post_trim/{sample}.{unit}.{read}.html",
+        zip="output/qc/fastqc_post_trim/{sample}.{unit}.{read}_fastqc.zip" # the suffix _fastqc.zip is necessary for multiqc to find the file. If not using multiqc, you are free to choose an arbitrary filename
+    benchmark:
+        "output/benchmarks/qc/fastqc_post_trim/{sample}.{unit}.{read}_benchmark.txt"
+    log:
+        "output/logs/qc/fastqc_post_trim/{sample}.{unit}.{read}.log"
     params: ""
     threads:
         config['threads']['fastqc_post_trim']
     wrapper:
         "0.72.0/bio/fastqc"
 
-
 rule merge_units:
     input:
-        lambda wildcards: expand("output/trimmed/{sample}.{sequnit}.{read}.fastq.gz",
+        lambda wildcards: expand("output/qc/cutadapt_pe/{sample}.{sequnit}.{read}.fastq.gz",
                                  sample=wildcards.sample,
                                  sequnit=list(units_table.loc[wildcards.sample].index),
                                  read=wildcards.read)
     output:
-        temp("output/trimmed/{sample}.combined.{read}.fastq.gz")
+        temp("output/qc/merge_units/{sample}.combined.{read}.fastq.gz")
+    benchmark:
+        "output/benchmarks/qc/merge_units/{sample}.combined.{read}_benchmark.txt"
+    log:
+        "output/logs/qc/merge_units/{sample}.combined.{read}.log"
     params: ""
     threads: 1
     shell: "cat {input} > {output}"
@@ -67,12 +82,16 @@ rule download_NCBI_assembly:
     params:
         accn=config['host_filter']['accn']
     threads: 1
-    log: "output/logs/setup/download_NCBI_assembly.{accn}.log"
+    log:
+        "output/logs/qc/download_NCBI_assembly/{accn}.log"
+    benchmark:
+        "output/benchmarks/qc/merge_units/{accn}_benchmark.txt"
     conda:
         "../env/qc.yaml"
     shell: "esearch -db assembly -query {params.accn} | \
             elink -target nucleotide -name assembly_nuccore_insdc | \
-            efetch -format fasta > {output}"
+            efetch -format fasta > {output} \
+            2>> {log} 1>&2"
 
 rule host_bowtie2_build:
     input:
@@ -87,12 +106,10 @@ rule host_bowtie2_build:
                  ".4.bt2",
                  ".rev.1.bt2",
                  ".rev.2.bt2")
-    log:
-        "output/logs/host_bowtie2_build/bowtie2-build.log"
     conda:
         "../env/qc.yaml"
     params:
-        extra="",  # optional parameters,
+        extra="",  # optional parameters
         indexbase=join(config['host_filter']['db_dir'],
                        config['host_filter']['accn'])
     threads:
@@ -100,7 +117,7 @@ rule host_bowtie2_build:
     shell:
         """
         bowtie2-build --threads {threads} {params.extra} \
-        {input.reference} {params.indexbase} 2> {log} 1>&2
+        {input.reference} {params.indexbase}
         """
 
 rule host_filter:
@@ -121,13 +138,13 @@ rule host_filter:
     All piped output first written to localscratch to avoid tying up filesystem.
     """
     input:
-        fastq1="output/trimmed/{sample}.combined.R1.fastq.gz",
-        fastq2="output/trimmed/{sample}.combined.R2.fastq.gz",
+        fastq1="output/qc/merge_units/{sample}.combined.R1.fastq.gz",
+        fastq2="output/qc/merge_units/{sample}.combined.R2.fastq.gz",
         db=rules.host_bowtie2_build.output
     output:
-        nonhost_R1="output/filtered/nonhost/{sample}.1.fastq.gz",
-        nonhost_R2="output/filtered/nonhost/{sample}.2.fastq.gz",
-        host="output/filtered/host/{sample}.bam",
+        nonhost_R1="output/qc/host_filter/nonhost/{sample}.1.fastq.gz",
+        nonhost_R2="output/qc/host_filter/nonhost/{sample}.2.fastq.gz",
+        host="output/qc/host_filter/host/{sample}.bam",
     params:
         ref=join(config['host_filter']['db_dir'],
                  config['host_filter']['accn'])
@@ -136,38 +153,37 @@ rule host_filter:
     threads:
         config['threads']['host_filter']
     benchmark:
-        "output/benchmarks/host_filter/{sample}_benchmark.txt"
+        "output/benchmarks/qc/host_filter/{sample}_benchmark.txt"
     log:
-        "output/logs/host_filter/{sample}.bowtie.log"
+        "output/logs/qc/host_filter/{sample}.log"
     shell:
         """
         # Map reads against reference genome
         bowtie2 -p {threads} -x {params.ref} \
           -1 {input.fastq1} -2 {input.fastq2} \
           --un-conc-gz {wildcards.sample}_nonhost \
-          2> {log} | samtools view -bS - > {output.host}
+          2> {log} | samtools view -bS - > {output.host} 
 
         # rename nonhost samples
-        mv {wildcards.sample}_nonhost.1 output/filtered/nonhost/{wildcards.sample}.1.fastq.gz
-        mv {wildcards.sample}_nonhost.2 output/filtered/nonhost/{wildcards.sample}.2.fastq.gz
+        mv {wildcards.sample}_nonhost.1 output/qc/host_filter/nonhost/{wildcards.sample}.1.fastq.gz
+        mv {wildcards.sample}_nonhost.2 output/qc/host_filter/nonhost/{wildcards.sample}.2.fastq.gz
         """
 
 rule multiqc:
     input:
-        expand("output/qc/fastqc/pre_trim/{units.Index[0]}.{units.Index[1]}.{read}.html",
+        expand("output/qc/fastqc_pre_trim/{units.Index[0]}.{units.Index[1]}.{read}.html",
                units=units_table.itertuples(), read=reads),
-        expand("output/logs/cutadapt/{units.Index[0]}.{units.Index[1]}.qc.txt",
+        expand("output/logs/qc/cutadapt_pe/{units.Index[0]}.{units.Index[1]}.txt",
                units=units_table.itertuples()),
-        expand("output/qc/fastqc/post_trim/{units.Index[0]}.{units.Index[1]}.{read}.trimmed.html",
+        expand("output/qc/fastqc_post_trim/{units.Index[0]}.{units.Index[1]}.{read}.html",
                units=units_table.itertuples(), read=reads),
         lambda wildcards: expand(rules.host_filter.log,
-                                 sample=samples,
-                                 read=reads)
+                                 sample=samples)
     output:
         "output/qc/multiqc/multiqc.html"
     params:
         config['params']['multiqc']  # Optional: extra parameters for multiqc.
     log:
-        "output/logs/multiqc/multiqc.log"
+        "output/logs/qc/multiqc/multiqc.log"
     wrapper:
         "0.72.0/bio/multiqc"


### PR DESCRIPTION
addresses issue #43:
Changes env yaml files to reflect the snakemake module, to improve modularity
also renamed sourmash.smk and sourmash.yaml to prototype_selection, to make naming more in line with other modules (i.e. reflect the output/goal instead of the tools). 