### PR TITLE
Fix host removal

### DIFF
--- a/resources/snakefiles/assemble.smk
+++ b/resources/snakefiles/assemble.smk
@@ -114,7 +114,7 @@ rule multiqc_assemble:
     output:
         "output/assemble/multiqc_assemble/multiqc.html"
     params:
-        config['params']['multiqc']  # Optional: extra parameters for multiqc.
+        "--dirs " + config['params']['multiqc']  # Optional: extra parameters for multiqc.
     log:
         "output/logs/assemble/multiqc_assemble/multiqc_assemble.log"
     benchmark:
@@ -162,7 +162,7 @@ rule multiqc_metaquast:
     output:
         "output/assemble/multiqc_metaquast/multiqc.html"
     params:
-        config['params']['multiqc']  # Optional: extra parameters for multiqc.
+        "--dirs " + config['params']['multiqc']  # Optional: extra parameters for multiqc.
     log:
         "output/logs/assemble/multiqc_metaquast/multiqc_metaquast.log"
     benchmark:

--- a/resources/snakefiles/qc.smk
+++ b/resources/snakefiles/qc.smk
@@ -154,11 +154,11 @@ rule host_filter:
         bowtie2 -p {threads} -x {params.ref} \
           -1 {input.fastq1} -2 {input.fastq2} \
           --un-conc-gz {wildcards.sample}_nonhost \
-          2> {log} | samtools view -bS - > {output.host} 
+          2> {log} | samtools view -bS - > {output.host}
 
         # rename nonhost samples
-        mv {wildcards.sample}_nonhost.1 output/qc/host_filter/nonhost/{wildcards.sample}.R1.fastq.gz
-        mv {wildcards.sample}_nonhost.2 output/qc/host_filter/nonhost/{wildcards.sample}.R2.fastq.gz
+        cp {wildcards.sample}_nonhost.1 output/qc/host_filter/nonhost/{wildcards.sample}.R1.fastq.gz
+        cp {wildcards.sample}_nonhost.2 output/qc/host_filter/nonhost/{wildcards.sample}.R2.fastq.gz
         """
 
 rule fastqc_post_host:

--- a/resources/snakefiles/qc.smk
+++ b/resources/snakefiles/qc.smk
@@ -193,7 +193,7 @@ rule multiqc:
     output:
         "output/qc/multiqc/multiqc.html"
     params:
-        config['params']['multiqc']  # Optional: extra parameters for multiqc.
+        "--dirs " + config['params']['multiqc']  # Optional: extra parameters for multiqc.
     log:
         "output/logs/qc/multiqc/multiqc.log"
     benchmark:

--- a/resources/snakefiles/qc.smk
+++ b/resources/snakefiles/qc.smk
@@ -97,8 +97,7 @@ rule host_bowtie2_build:
                  ".rev.1.bt2",
                  ".rev.2.bt2")
     log:
-        "output/logs/host_bowtie2_build/{0}.log".format(
-            config['host_filter']['accn'])
+        "output/logs/host_bowtie2_build/host_bowtie2_build.log"
     benchmark:
         "output/benchmarks/qc/host_bowtie2_build/host_bowtie2_build_benchmark.txt"
     conda:

--- a/resources/snakefiles/qc.smk
+++ b/resources/snakefiles/qc.smk
@@ -154,11 +154,12 @@ rule host_filter:
         bowtie2 -p {threads} -x {params.ref} \
           -1 {input.fastq1} -2 {input.fastq2} \
           --un-conc-gz {wildcards.sample}_nonhost \
+          --no-unal \
           2> {log} | samtools view -bS - > {output.host}
 
         # rename nonhost samples
-        cp {wildcards.sample}_nonhost.1 output/qc/host_filter/nonhost/{wildcards.sample}.R1.fastq.gz
-        cp {wildcards.sample}_nonhost.2 output/qc/host_filter/nonhost/{wildcards.sample}.R2.fastq.gz
+        mv {wildcards.sample}_nonhost.1 output/qc/host_filter/nonhost/{wildcards.sample}.R1.fastq.gz
+        mv {wildcards.sample}_nonhost.2 output/qc/host_filter/nonhost/{wildcards.sample}.R2.fastq.gz
         """
 
 rule fastqc_post_host:
@@ -192,7 +193,7 @@ rule multiqc:
     output:
         "output/qc/multiqc/multiqc.html"
     params:
-        "--dirs " + config['params']['multiqc']  # Optional: extra parameters for multiqc.
+        config['params']['multiqc']  # Optional: extra parameters for multiqc.
     log:
         "output/logs/qc/multiqc/multiqc.log"
     benchmark:


### PR DESCRIPTION
added `--no-unal` flag to host_filter rule. Results in host bam file being limited to only reads mapping to the host genome.