### PR TITLE
Make sorted bams temp

### DIFF
--- a/resources/snakefiles/mapping.smk
+++ b/resources/snakefiles/mapping.smk
@@ -122,8 +122,8 @@ rule sort_index_bam:
     input:
         aln="output/mapping/{mapper}/mapped_reads/{read_sample}_Mapped_To_{contig_sample}.bam"
     output:
-        bam="output/mapping/{mapper}/sorted_bams/{read_sample}_Mapped_To_{contig_sample}.sorted.bam",
-        bai="output/mapping/{mapper}/sorted_bams/{read_sample}_Mapped_To_{contig_sample}.sorted.bam.bai"
+        bam=temp("output/mapping/{mapper}/sorted_bams/{read_sample}_Mapped_To_{contig_sample}.sorted.bam"),
+        bai=temp("output/mapping/{mapper}/sorted_bams/{read_sample}_Mapped_To_{contig_sample}.sorted.bam.bai")
     conda:
         "../env/mapping.yaml"
     threads:

--- a/resources/snakefiles/qc.smk
+++ b/resources/snakefiles/qc.smk
@@ -193,7 +193,7 @@ rule multiqc:
     output:
         "output/qc/multiqc/multiqc.html"
     params:
-        config['params']['multiqc']  # Optional: extra parameters for multiqc.
+        "--dirs " + config['params']['multiqc']  # Optional: extra parameters for multiqc.
     log:
         "output/logs/qc/multiqc/multiqc.log"
     benchmark:

--- a/resources/snakefiles/qc.smk
+++ b/resources/snakefiles/qc.smk
@@ -97,7 +97,7 @@ rule host_bowtie2_build:
                  ".rev.1.bt2",
                  ".rev.2.bt2")
     log:
-        "output/logs/host_bowtie2_build/host_bowtie2_build.log"
+        "output/logs/qc/host_bowtie2_build/host_bowtie2_build.log"
     benchmark:
         "output/benchmarks/qc/host_bowtie2_build/host_bowtie2_build_benchmark.txt"
     conda:


### PR DESCRIPTION
added a `temp` declaration to the outputs of rule `sort_index_bam`, to help keep file storage overhead lower. 