### PR TITLE
Maxbin file structure

### DIFF
--- a/resources/snakefiles/binning.smk
+++ b/resources/snakefiles/binning.smk
@@ -22,7 +22,6 @@ rule make_metabat2_coverage_table:
         "output/logs/binning/metabat2/{mapper}/make_metabat2_coverage_table/{contig_sample}.log"
     shell:
         """
-            echo {input.bams}
             jgi_summarize_bam_contig_depths --outputDepth {output.coverage_table} {input.bams} 2> {log}
         """
 
@@ -122,10 +121,8 @@ rule run_maxbin2:
                 mapper=config['mappers'],
                 contig_sample=wildcards.contig_sample)
     output:
-        bins = "output/binning/maxbin2/{mapper}/run_maxbin2/{contig_sample}_bins"
-        #bins = directory("output/binning/maxbin2/{mapper}/run_maxbin2/{contig_sample}/")
+        bins = "output/binning/maxbin2/{mapper}/run_maxbin2/{contig_sample}/{contig_sample}_bins"
     params:
-        #basename = "output/binning/maxbin2/{mapper}/run_maxbin2/{contig_sample}/{contig_sample}_bin",
         prob = config['params']['maxbin2']['prob_threshold'],  # optional parameters
         extra = config['params']['maxbin2']['extra']  # optional parameters
     threads:

--- a/resources/snakefiles/mapping.smk
+++ b/resources/snakefiles/mapping.smk
@@ -64,9 +64,6 @@ rule map_reads_bt2:
 
 rule index_contigs_minimap2:
     input:
-        # contigs = lambda wildcards: expand("output/assemble/{assembler}/{contig_sample}.contigs.fasta",
-        #                          assembler=config['assemblers'],
-        #                          read=wildcards.contig_sample)
         contigs = lambda wildcards: get_contigs(wildcards.contig_sample,
                                                 binning_df)
     output:

--- a/resources/snakefiles/mapping.smk
+++ b/resources/snakefiles/mapping.smk
@@ -122,8 +122,8 @@ rule sort_index_bam:
     input:
         aln="output/mapping/{mapper}/mapped_reads/{read_sample}_Mapped_To_{contig_sample}.bam"
     output:
-        bam="output/mapping/{mapper}/sorted_bams/{read_sample}_Mapped_To_{contig_sample}.sorted.bam",
-        bai="output/mapping/{mapper}/sorted_bams/{read_sample}_Mapped_To_{contig_sample}.sorted.bam.bai"
+        bam=temp("output/mapping/{mapper}/sorted_bams/{read_sample}_Mapped_To_{contig_sample}.sorted.bam"),
+        bai=temp("output/mapping/{mapper}/sorted_bams/{read_sample}_Mapped_To_{contig_sample}.sorted.bam.bai")
     conda:
         "../env/mapping.yaml"
     threads:

--- a/resources/snakefiles/qc.smk
+++ b/resources/snakefiles/qc.smk
@@ -193,7 +193,7 @@ rule multiqc:
     output:
         "output/qc/multiqc/multiqc.html"
     params:
-        config['params']['multiqc']  # Optional: extra parameters for multiqc.
+        "--dirs " + config['params']['multiqc']  # Optional: extra parameters for multiqc.
     log:
         "output/logs/qc/multiqc/multiqc.log"
     benchmark:

--- a/resources/snakefiles/qc.smk
+++ b/resources/snakefiles/qc.smk
@@ -97,7 +97,7 @@ rule host_bowtie2_build:
                  ".rev.1.bt2",
                  ".rev.2.bt2")
     log:
-        "output/logs/host_bowtie2_build/host_bowtie2_build.log"
+        "output/logs/qc/host_bowtie2_build/host_bowtie2_build.log"
     benchmark:
         "output/benchmarks/qc/host_bowtie2_build/host_bowtie2_build_benchmark.txt"
     conda:


### PR DESCRIPTION
Added `{contig_sample}/` to output of `run_maxbin2` rule so that the file structure is the same as the output of `run_metabat2` 

Delete `echo {input.bams}` from `make_metabat2_coverage_table`, which had been added for troubleshooting purposes. 

Delete commented lines from `run_maxbin2`, as well as `index_contigs_minimap2`