### PR TITLE
updated minimap2 version

### DIFF
--- a/resources/env/mapping.yaml
+++ b/resources/env/mapping.yaml
@@ -1,5 +1,6 @@
 channels:
   - bioconda
+  - conda-forge
 dependencies:
   - python>=3.5
   - bowtie2>=2.3.0
@@ -8,4 +9,5 @@ dependencies:
   - pigz
   - entrez-direct
   - tbb=2020.2
-  - minimap2
+  - libzlib=1.2.12
+  - minimap2=2.24


### PR DESCRIPTION
mapping step was throwing error for Sam. Had to specify that we wanted the latest version (2.24) of `minimap`, also dependecy `libzlib=1.2.12`, which also required the `conda-forge` channel. 